### PR TITLE
Print username on log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ default: build
 ci: depsdev test integration vet lint
 
 depsdev: ## Installing dependencies for development
-	$(GO) get golang.org/x/lint/golint
+	$(GO) install golang.org/x/lint/golint@latest
 
 server:
 	$(GO) run main.go

--- a/docker/ssh-proxy/Dockerfile
+++ b/docker/ssh-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-stretch
+FROM golang:1.20
 
 RUN mkdir -p /home/tsurubee/.ssh /home/hoge/.ssh
 

--- a/go.mod
+++ b/go.mod
@@ -1,18 +1,23 @@
 module github.com/tsurubee/sshr
 
+go 1.20
+
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Gurpartap/logrus-stack v0.0.0-20170710170904-89c00d8a28f4
+	github.com/lestrrat/go-server-starter v0.0.0-20180220115249-6ac0b358431b
+	github.com/pkg/sftp v1.10.0
+	github.com/sirupsen/logrus v1.4.1
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
+	golang.org/x/sync v0.1.0
+)
+
+require (
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/fs v0.1.0 // indirect
-	github.com/lestrrat/go-server-starter v0.0.0-20180220115249-6ac0b358431b
 	github.com/pkg/errors v0.8.1 // indirect
-	github.com/pkg/sftp v1.10.0
-	github.com/sirupsen/logrus v1.4.1
 	github.com/stretchr/testify v1.3.0 // indirect
-	golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5
-	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6
 	golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -7,7 +7,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojtoVVWjGfOF9635RETekkoH6Cc9SX0A=
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
-github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -25,14 +24,13 @@ github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tsurubee/sshr.crypto v0.0.0-20200227043732-5db8c8aac292 h1:yTbEqDRnrFBUuJXjjqo+GeAJRRmuuYprbVLJifVHJzY=
 github.com/tsurubee/sshr.crypto v0.0.0-20200227043732-5db8c8aac292/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
-golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0Is3p+EHBKNgquIzo1OI=
-golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67 h1:1Fzlr8kkDLQwqMP8GxrhptBLqZG/EDpiATneiZHY998=

--- a/integration_test.go
+++ b/integration_test.go
@@ -3,16 +3,16 @@ package main
 import (
 	"bytes"
 	"flag"
-	"testing"
-	"os"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path"
-	"time"
 	"strings"
-	"golang.org/x/crypto/ssh"
+	"testing"
+	"time"
+
 	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
 )
 
 var (
@@ -41,7 +41,7 @@ func loginByPassword(username string, port int, password string) (*ssh.Client, *
 }
 
 func loginByPublicKey(username string, port int, keyPath string) (*ssh.Client, *ssh.Session, error) {
-	privateKeyBytes, err := ioutil.ReadFile(keyPath)
+	privateKeyBytes, err := os.ReadFile(keyPath)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -88,7 +88,7 @@ func uploadFileByScp(sess *ssh.Session, uploadFile string, permission string) er
 	defer f.Close()
 	filename := path.Base(uploadFile)
 
-	contentsBytes, err := ioutil.ReadAll(f)
+	contentsBytes, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}
@@ -171,7 +171,7 @@ func TestLoginByPassword(t *testing.T) {
 			name:     "success login",
 			username: "tsurubee",
 			password: "failpass",
-			wantErr:   true,
+			wantErr:  true,
 		},
 	}
 

--- a/sshr/config.go
+++ b/sshr/config.go
@@ -1,9 +1,10 @@
 package sshr
 
 import (
+	"os"
+
 	"github.com/BurntSushi/toml"
 	"golang.org/x/crypto/ssh"
-	"io/ioutil"
 )
 
 type config struct {
@@ -31,7 +32,7 @@ func newServerConfig(c *config) (*ssh.ServerConfig, error) {
 	serverConfig := &ssh.ServerConfig{}
 
 	for _, k := range c.HostKeyPath {
-		privateKeyBytes, err := ioutil.ReadFile(k)
+		privateKeyBytes, err := os.ReadFile(k)
 		if err != nil {
 			return nil, err
 		}

--- a/sshr/logger.go
+++ b/sshr/logger.go
@@ -10,7 +10,7 @@ type logger struct {
 	user string
 }
 
-func (l *logger) info(format string, args ...interface{}) {
+func (l *logger) infof(format string, args ...interface{}) {
 	format = fmt.Sprintf("[user:%s] %s", l.user, format)
 	logrus.Infof(format, args...)
 }

--- a/sshr/logger.go
+++ b/sshr/logger.go
@@ -1,0 +1,16 @@
+package sshr
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+type logger struct {
+	user string
+}
+
+func (l *logger) info(format string, args ...interface{}) {
+	format = fmt.Sprintf("[user:%s] %s", l.user, format)
+	logrus.Infof(format, args...)
+}

--- a/sshr/server.go
+++ b/sshr/server.go
@@ -116,7 +116,7 @@ func (server *SSHServer) Run() error {
 		done <- struct{}{}
 	}()
 
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGHUP, syscall.SIGTERM)
 Loop:
 	for {

--- a/sshr/server.go
+++ b/sshr/server.go
@@ -88,12 +88,12 @@ func (server *SSHServer) serve() error {
 				logger.user = p.User
 			}
 			if err != nil {
-				logger.info("Connection from %s closed. %v", tcpConn.RemoteAddr().String(), err)
+				logger.infof("Connection from %s closed. %v", tcpConn.RemoteAddr().String(), err)
 				return err
 			}
-			logger.info("Establish a proxy connection between %s and %s", tcpConn.RemoteAddr().String(), p.DestinationHost)
+			logger.infof("Establish a proxy connection between %s and %s", tcpConn.RemoteAddr().String(), p.DestinationHost)
 			err = p.Wait()
-			logger.info("Connection from %s closed.", tcpConn.RemoteAddr().String())
+			logger.infof("Connection from %s closed.", tcpConn.RemoteAddr().String())
 			return err
 		})
 	}

--- a/sshr/server.go
+++ b/sshr/server.go
@@ -81,7 +81,7 @@ func (server *SSHServer) serve() error {
 
 		eg.Go(func() error {
 			logger := &logger{
-				user: "unknown",
+				user: "-",
 			}
 			p, err := newSSHProxyConn(tcpConn, server.ProxyConfig)
 			if p != nil {

--- a/sshr/server.go
+++ b/sshr/server.go
@@ -84,11 +84,13 @@ func (server *SSHServer) serve() error {
 				user: "unknown",
 			}
 			p, err := newSSHProxyConn(tcpConn, server.ProxyConfig)
+			if p != nil {
+				logger.user = p.User
+			}
 			if err != nil {
 				logger.info("Connection from %s closed. %v", tcpConn.RemoteAddr().String(), err)
 				return err
 			}
-			logger.user = p.User
 			logger.info("Establish a proxy connection between %s and %s with username %s", tcpConn.RemoteAddr().String(), p.DestinationHost, p.User)
 			err = p.Wait()
 			logger.info("Connection from %s closed.", tcpConn.RemoteAddr().String())

--- a/sshr/server.go
+++ b/sshr/server.go
@@ -91,7 +91,7 @@ func (server *SSHServer) serve() error {
 				logger.info("Connection from %s closed. %v", tcpConn.RemoteAddr().String(), err)
 				return err
 			}
-			logger.info("Establish a proxy connection between %s and %s with username %s", tcpConn.RemoteAddr().String(), p.DestinationHost, p.User)
+			logger.info("Establish a proxy connection between %s and %s", tcpConn.RemoteAddr().String(), p.DestinationHost)
 			err = p.Wait()
 			logger.info("Connection from %s closed.", tcpConn.RemoteAddr().String())
 			return err


### PR DESCRIPTION
## Overview

Append ssh username in front of sshr's log for helps to discover which user has connected.

## Diff

- As-Is

```
sshr-ssh-proxy-1      | time="2023-03-20T09:50:44Z" level=info msg="SSH Client connected. ClientIP=172.31.0.1:57990"
sshr-ssh-proxy-1      | time="2023-03-20T09:50:44Z" level=info msg="Establish a proxy connection between 172.31.0.1:57990 and host-tsurubee"
sshr-ssh-proxy-1      | time="2023-03-20T09:50:44Z" level=info msg="Connection from 172.31.0.1:57990 closed. EOF"
```

- To-Be

```
sshr-ssh-proxy-1      | time="2023-03-20T09:47:33Z" level=info msg="SSH Client connected. ClientIP=172.31.0.1:60934"
sshr-ssh-proxy-1      | time="2023-03-20T09:47:33Z" level=info msg="[user:tsurubee] Establish a proxy connection between 172.31.0.1:60934 and host-tsurubee"
sshr-ssh-proxy-1      | time="2023-03-20T09:47:33Z" level=info msg="[user:tsurubee] Connection from 172.31.0.1:60934 closed."
```

## Others

Fix some codes for matching golang version 1.20.

- change os signal channel to buffer channel
- io/ioutil is deprecated after Go 1.16
- go get is not install binary anymore